### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/AlexisLeBoulanger/26d6ce51-7808-4a63-a717-472cd0dca47b/053f358c-a3e1-4781-a1bf-c23a91b9c952/_apis/work/boardbadge/f8171011-4aec-4e62-b5ba-22c172aa5cb6)](https://dev.azure.com/AlexisLeBoulanger/26d6ce51-7808-4a63-a717-472cd0dca47b/_boards/board/t/053f358c-a3e1-4781-a1bf-c23a91b9c952/Microsoft.RequirementCategory)
 # ASPNETWebAppSample


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#96](https://dev.azure.com/AlexisLeBoulanger/26d6ce51-7808-4a63-a717-472cd0dca47b/_workitems/edit/96). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.